### PR TITLE
Fix npcs no se giran para pegar

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -22184,6 +22184,10 @@ Public Function PrepareMessageCharacterChange(ByVal body As Integer, _
         Call .WriteInteger(FX)
         Call .WriteInteger(FXLoops)
         
+        Call .WriteByte(ServerPacketID.HeadingChange)
+        Call .WriteInteger(CharIndex)
+        Call .WriteByte(heading)
+        
         PrepareMessageCharacterChange = .ReadASCIIStringFixed(.Length)
 
     End With


### PR DESCRIPTION
Por alguna razón no se envia el heading en el paquete CharacterChange. Podría haber modificado el paquete tanto en cliente y en servidor, pero para no hacer tanto cambio, hice un poco de trampa y simplemente le adjunto el paquete de cambio de heading.